### PR TITLE
Remove trailing slashes and update redirected Ultralytics URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Minimal Reproducible Example
       description: >
-        When asking a question, people will be better able to provide help if you provide code that they can easily understand and use to **reproduce** the problem. This is referred to by community members as creating a [minimal reproducible example](https://docs.ultralytics.com/help/minimum-reproducible-example/).
+        When asking a question, people will be better able to provide help if you provide code that they can easily understand and use to **reproduce** the problem. This is referred to by community members as creating a [minimal reproducible example](https://docs.ultralytics.com/help/minimum-reproducible-example).
       placeholder: |
         ```bash
         docker build -t xview .

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,7 +6,7 @@ contact_links:
     url: https://github.com/ultralytics/xview-docker#readme
     about: Repository overview and usage
   - name: 💬 Forum
-    url: https://community.ultralytics.com/
+    url: https://community.ultralytics.com
     about: Ask on Ultralytics Community Forum
   - name: 🎧 Discord
     url: https://ultralytics.com/discord

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # Introduction 👋
 
-Welcome to the Ultralytics xView Docker submission repository! This codebase is open-source and distributed under the [AGPL-3.0 license](https://www.ultralytics.com/legal/agpl-3-0-software-license). Discover more about Ultralytics and our innovative projects by visiting our official website at [https://www.ultralytics.com](https://www.ultralytics.com/).
+Welcome to the Ultralytics xView Docker submission repository! This codebase is open-source and distributed under the [AGPL-3.0 license](https://www.ultralytics.com/legal/agpl-3-0-software-license). Discover more about Ultralytics and our innovative projects by visiting our official website at [https://www.ultralytics.com](https://www.ultralytics.com).
 
 [![Ultralytics Actions](https://github.com/ultralytics/xview-docker/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/xview-docker/actions/workflows/format.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
-[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
+[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
 
 # Project Overview 📄
@@ -77,7 +77,7 @@ Your container can now be found hosted at [https://hub.docker.com/r/ultralytics/
 
 # Contribute 🤝
 
-We warmly welcome contributions from the community! Whether it's fixing bugs, adding new features, or enhancing documentation, your input is highly valuable. Please refer to our [Contributing Guide](https://docs.ultralytics.com/help/contributing/) to get started. We're also keen to hear about your experiences with Ultralytics products—please consider filling out our [Survey](https://www.ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey). A huge 🙏 thank you to all our contributors!
+We warmly welcome contributions from the community! Whether it's fixing bugs, adding new features, or enhancing documentation, your input is highly valuable. Please refer to our [Contributing Guide](https://docs.ultralytics.com/help/contributing) to get started. We're also keen to hear about your experiences with Ultralytics products—please consider filling out our [Survey](https://www.ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey). A huge 🙏 thank you to all our contributors!
 
 [![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/xview-docker/graphs/contributors)
 
@@ -85,7 +85,7 @@ We warmly welcome contributions from the community! Whether it's fixing bugs, ad
 
 Ultralytics provides two licensing options to accommodate diverse needs:
 
-- **AGPL-3.0 License**: Ideal for students and enthusiasts, this [OSI-approved](https://opensource.org/license/agpl-v3) open-source license promotes collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/xview-docker/blob/main/LICENSE) file for details.
+- **AGPL-3.0 License**: Ideal for students and enthusiasts, this [OSI-approved](https://opensource.org/license/agpl-3.0) open-source license promotes collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/xview-docker/blob/main/LICENSE) file for details.
 - **Enterprise License**: Designed for commercial applications, this license permits the integration of Ultralytics software and AI models into commercial products without the open-source obligations of AGPL-3.0. For commercial use cases, please contact us via [Ultralytics Licensing](https://www.ultralytics.com/license).
 
 # Contact Us 📬


### PR DESCRIPTION
## Summary

Normalizes Ultralytics URLs in this repo to the canonical no-trailing-slash form and refreshes one permanently redirected external link.

### Trailing slashes removed (6)

| File | Link |
| --- | --- |
| `README.md` | `https://www.ultralytics.com/` (logo href) |
| `README.md` | `https://www.ultralytics.com/` (intro paragraph link target) |
| `README.md` | `https://community.ultralytics.com/` (Forums badge link) |
| `README.md` | `https://docs.ultralytics.com/help/contributing/` |
| `.github/ISSUE_TEMPLATE/bug-report.yml` | `https://docs.ultralytics.com/help/minimum-reproducible-example/` |
| `.github/ISSUE_TEMPLATE/config.yml` | `https://community.ultralytics.com/` (Forum contact link) |

Only slashes that terminate a path were touched; path separators, URL-encoded URLs, and vanity shortlinks were left alone. All six de-slashed targets were verified to return HTTP 200 directly.

### Redirects updated (1 accepted)

- `https://opensource.org/license/agpl-v3` -> `https://opensource.org/license/agpl-3.0` — single 301 to the renamed OSI license slug, terminal 200.

### Redirects rejected (1)

- `https://reddit.com/r/ultralytics` -> `https://www.reddit.com/r/ultralytics/` — host canonicalization only, not a content move. The destination re-adds a trailing slash, and the same link appears in `.github/ISSUE_TEMPLATE/config.yml` as a bare URL that link-rewriting does not reach, so baking it in would make the two copies inconsistent for zero benefit.

### Deliberately preserved

- `https://ultralytics.com/discord` and `https://ultralytics.com/bilibili` — vanity shortlinks meant to stay redirects.
- `server=https%3A%2F%2Fcommunity.ultralytics.com` inside the shields.io Forums badge — URL-encoded parameter kept byte-identical.
- `https://ultralytics.com/license` headers — written by Ultralytics Actions, already slash-free.

No dead links were found. No non-URL text changed; `prettier@3.8.5 --print-width 120 --check` passes on all touched files and all workflow/issue-template YAML still parses.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated repository links to use canonical no-trailing-slash URLs and replaced the outdated Open Source Initiative AGPL license link with its current destination.

### 📊 Key Changes

- Removed trailing slashes from Ultralytics website, Community Forum, documentation, and contributing links in `README.md` and issue-template YAML files.
- Updated the OSI license URL from `https://opensource.org/license/agpl-v3` to `https://opensource.org/license/agpl-3.0`.
- Preserved vanity redirects such as the Discord and Bilibili links, the encoded Forums badge URL, and the Reddit link.
- No non-URL text was changed; formatting and YAML validation checks passed according to the PR context.

### 🎯 Purpose & Impact

- Repository documentation and issue-template links now use consistent canonical URLs, while the license reference points to the renamed OSI page.
- No functional or user-facing workflow change.